### PR TITLE
(feature/issueLabeler)- Github action adds GSSOC21 label

### DIFF
--- a/.github/workflows/issueLabeler.yml
+++ b/.github/workflows/issueLabeler.yml
@@ -1,0 +1,14 @@
+name: issue-labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'GSSOC21'


### PR DESCRIPTION
# Description
Github action which adds the GSSOC21 label to all new issues being opened.

Fixes #30 


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Tested on a personal repository I have


# Checklist:
<!---In order to check the boxes simply put x in the square bracket like this [x]--->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
